### PR TITLE
* Fixed namespace typo for DomainParser

### DIFF
--- a/Parser.php
+++ b/Parser.php
@@ -253,7 +253,7 @@ class Parser
             $this->Query = new \stdClass();
             $this->Query->asn = $query;
         } else {
-            $Parser = new \Novutec\Domainparser\Parser();
+            $Parser = new \Novutec\DomainParser\Parser();
             $this->Query = $Parser->parse(filter_var($query, FILTER_SANITIZE_STRING));
         }
     }


### PR DESCRIPTION
I have fixed a typo on Parser.php for namespace definition of DomainParser which was causing a fatal error. 
