### PR TITLE
wrong template for .name

### DIFF
--- a/Config/whois.ini
+++ b/Config/whois.ini
@@ -340,7 +340,8 @@ na[server] = whois.na-nic.com.na
 na[template] = afilias
 
 name[server] = whois.nic.name
-name[template] = afilias
+name[format] = domain %domain%
+name[template] = verisign
 
 nc[server] = whois.nc
 nc[template] = nc


### PR DESCRIPTION
Whois on .name used the wrong template. This should be verisign
