### PR TITLE
Prevent from crashes when using squid for proxies

### DIFF
--- a/Adapter/Socket.php
+++ b/Adapter/Socket.php
@@ -59,6 +59,7 @@ class Socket extends AbstractAdapter
         $this->disconnect();
         $this->connect($config);
 
+        usleep(1);
         stream_set_blocking($this->sock, 1);
 
         if (isset($query->tld) && ! isset($query->idnFqdn)) {


### PR DESCRIPTION
When using squid `Novutec\WhoisParser\Socket` is writing domain name directly to squid instead of whois server, which hasn't been connected to yet.

http://www.squid-cache.org/
