### PR TITLE
Fixed invalid ipv4 addresses lookup on 32bit systems

### DIFF
--- a/Parser.php
+++ b/Parser.php
@@ -358,7 +358,7 @@ class Parser
     private function ip2bin($ip)
     {
         if (filter_var($ip, FILTER_VALIDATE_IP, FILTER_FLAG_IPV4) !== false) {
-            return base_convert(ip2long($ip), 10, 2);
+            return base_convert(sprintf('%u', ip2long($ip)), 10, 2);
         }
         
         if (filter_var($ip, FILTER_VALIDATE_IP, FILTER_FLAG_IPV6) === false) {


### PR DESCRIPTION
Hi

There's a problem with ipv4 lookup on 32bit systems, because ip2long may return a negative number due to a signed integer overflow. 

Quoting: http://php.net/manual/en/language.types.integer.php
The size of an integer is platform-dependent, although a maximum value of about two billion is the usual value (that's 32 bits signed). 64-bit platforms usually have a maximum value of about 9E18. PHP does not support unsigned integers. Integer size can be determined using the constant PHP_INT_SIZE, and maximum value using the constant PHP_INT_MAX since PHP 4.4.0 and PHP 5.0.5.

32bit only:
When you try to lookup '194.67.32.107', the following occurs in https://github.com/novutec/WhoisParser/blob/master/Parser.php#L360:
1. ip2long('194.67.32.107') = int(-1035788181)
2. base_convert(-1035788181) = base_convert(1035788181) = string(30) "111101101111001101111110010101"
   But it's wrong because base_convert actually leaves out '-', so that, for instance,
   base_convert(-5, 10, 2) = base_convert(5, 10, 2) 
   hence the output of ip2long is incorrect
3. bin2ip https://github.com/novutec/WhoisParser/blob/master/Parser.php#L260
   returns string(14) "61.188.223.149"
4. this comparison fails: if ($this->bin2ip($this->ip2bin($query)) === $query) 
5. the lookup method ends up looking up '194.67.32.107.com'

The solution is to explicitly convert ip2long output to a string representation of unsigned int.
