### PR TITLE
Fix Afnic template exception for myamazon.fr

### DIFF
--- a/Templates/Afnic.php
+++ b/Templates/Afnic.php
@@ -126,6 +126,9 @@ class Afnic extends Regex
                 }
 
                 if ($contactType !== 'owner') {
+                    if(!is_array($filteredAddress)) {
+                        $filteredAddress = array($filteredAddress);
+                    }
                     $contactObject->organization = $filteredAddress[0];
                     $contactObject->city = end($filteredAddress);
                     unset($filteredAddress[0]);

--- a/Templates/Su.php
+++ b/Templates/Su.php
@@ -29,7 +29,7 @@ class Su extends KeyValue
             $this->data['state'] = explode(', ', $this->data['state']);
         }
 
-        $dateFields = ['created', 'free-date', 'paid-till'];
+        $dateFields = array('created', 'free-date', 'paid-till');
         foreach ($dateFields as $field) {
             if (array_key_exists($field, $this->data)) {
                 $this->data[$field] = str_replace('.', '-', $this->data[$field]);


### PR DESCRIPTION
A fix for the following issue that we had when we tried to parse myamazon.fr whois data

```
Warning Error: end() expects parameter 1 to be array, string given in [/novutec/WhoisParser/Templates/Afnic.php, line 125]

2016-05-12 19:32:14 Warning: end() expects parameter 1 to be array, string given in [/Vendor/novutec/WhoisParser/Templates/Afnic.php, line 125]
PHP Fatal error:  Cannot unset string offsets in /Vendor/novutec/WhoisParser/Templates/Afnic.php on line 126
```
